### PR TITLE
Fixed oc login URL (to expanded bitly)

### DIFF
--- a/OpenShift4/README.md
+++ b/OpenShift4/README.md
@@ -25,7 +25,7 @@
 
   - [Click Here to Download OC CLI Tool](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.1.4)
   - To login in via the Command Line:
-    - oc login http://bit.ly/OCPcommand813 -u user# -p r3dh4t1!
+    - oc login https://api.cluster-nyc-9db0.nyc-9db0.openshiftworkshop.com:6443/ -u user# -p r3dh4t1!
   - To login via the Web Console:
     - http://bit.ly/OCPNYC813
 


### PR DESCRIPTION
oc login with the bitly URL fails, needs the expanded URL